### PR TITLE
Release 4.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Fixed
-* Unify generation of unique identifier for resumable files (#31)
 
 ### Changed
 
 ### Removed
+
+## [4.0.0]
+### BREAKING
+Unique identifiers by default do not use the relative path anymore. This means that there is no support for files with the same name from different subfolders when dropping a folder directly.
+### Fixed
+* Unify generation of unique identifier for resumable files (#31)
 
 ## [3.0.0]
 ### BREAKING

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resumablejs",
-  "version": "3.0.0",
+  "version": "4.0.0",
   "description": "A JavaScript library for providing multiple simultaneous, stable, fault-tolerant and resumable/restartable uploads via the HTML5 File API.",
   "main": "dist/main.js",
   "private": false,


### PR DESCRIPTION
## [4.0.0]
### BREAKING
Unique identifiers by default do not use the relative path anymore. This means that there is no support for files with the same name from different subfolders when dropping a folder directly.
### Fixed
* Unify generation of unique identifier for resumable files (#31)