### PR TITLE
Fix file validation for duplicate files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Fixed
+Fix file validation for duplicate files (#39)
 
 ### Changed
 
@@ -27,24 +28,24 @@ Unique identifiers by default do not use the relative path anymore. This means t
 
 ## [3.0.0]
 ### BREAKING
-* (#25) Many class properties and some functions are `private` now and can't be accessed from the outside anymore. While these are technically breaking changes, there shouldn't have been any use cases for using those properties/functions.  
-This **does not affect any of the options you can provide to the Resumable constructor**. Those did not change.  
+* (#25) Many class properties and some functions are `private` now and can't be accessed from the outside anymore. While these are technically breaking changes, there shouldn't have been any use cases for using those properties/functions.
+This **does not affect any of the options you can provide to the Resumable constructor**. Those did not change.
 All usable (not private) functions/properties are documented in the readme.
   The following class properties/functions are affected:
   * `Resumable` main class:
-    * Properties that are not readable and not writable anymore:  
+    * Properties that are not readable and not writable anymore:
     `clearInput`, `dragOverClass`, `fileCategories`, `defaultFileCategory`, `fileTypes`, `fileTypeErrorCallback`, `_generateUniqueIdentifier`, `maxFileSize`, `maxFileSizeErrorCallback`, `maxFiles`, `maxFilesErrorCallback`, `minFileSize`, `minFileSizeErrorCallback`, `prioritizeFirstAndLastChunk`, `fileValidationErrorCallback`, `simultaneousUploads`
-    * Functions that can't be called from the outside anymore:  
+    * Functions that can't be called from the outside anymore:
       `checkUploadComplete()`
   * `ResumableFile` class:
-    * Properties that are not writable anymore, **but can still be read**:  
+    * Properties that are not writable anymore, **but can still be read**:
       `file`, `fileName`, `size`, `relativePath`, `uniqueIdentifier`, `fileCategory`, `chunks`
-    * Functions that can't be called from the outside anymore:  
+    * Functions that can't be called from the outside anymore:
       `bootstrap()`
   * `ResumableChunk` class:
-    * Properties that are not readable and not writable anymore:  
+    * Properties that are not readable and not writable anymore:
       `chunkNumberParameterName`, `chunkSizeParameterName`, `currentChunkSizeParameterName`, `totalSizeParameterName`, `typeParameterName`, `identifierParameterName`, `fileCategoryParameterName`, `fileNameParameterName`, `relativePathParameterName`, `totalChunksParameterName`, `throttleProgressCallbacks`, `query`, `headers`, `method`, `uploadMethod`, `testMethod`, `parameterNamespace`, `testChunks`, `maxChunkRetries`, `chunkRetryInterval`, `permanentErrors`, `withCredentials`, `xhrTimeout`, `chunkFormat`, `setChunkTypeFromFile`, `target`, `testTarget`
-    * Functions that can't be called from the outside anymore:  
+    * Functions that can't be called from the outside anymore:
       `setCustomHeaders()`, `test()`
 ### Added
 * Add optional verbose logging (#27)


### PR DESCRIPTION
# Long description

This fixes a bug in the validation when duplicate files are added to resumable.
The actual bug was at the end of the `validateFiles` function. Instead of checking the booleans (that decided if a file was validated or not) against the correct array of files (where duplicates were already removed) the booleans were compared to the original array of files.
The function now correctly uses the deduplicated array of files.

The other changes in the file are only to make this concept a bit more clear (renaming of some variables + an explanatory comment).
Additionally one debug log was fixed, because it previously printed the booleans instead of the validated files (another result of improper variable naming 😄).

Note: It also seems like the changelog file contained some windows(?) line endings, which were automatically changed when I saved the file. I guess this is fine?

# TODOs

* [x] I added an entry to the `CHANGELOG.md` for this PR
