### PR TITLE
Release v7.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### BREAKING
+
+### Added
+
+### Fixed
+
+### Changed
+
+### Removed
+
+## [7.0.0]
+### BREAKING
 * A file that encountered an error doesn't return `1` for its progress anymore. Instead it will return the progress at which it stopped uploading.
 * If a chunk encountered an error in the upload, it is now automatically retried in the final check.
     * Instead of reacting to `chunkError` or `fileError` events to manually retry such chunks, you should wait for the `failed` event.
@@ -16,12 +27,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * A `failed` event is now fired when Resumable is finished but some files couldn't be uploaded (#52)
 * Add `chunkStuckTimeout` option (#53)
 
-### Fixed
-
 ### Changed
 * Retry errored chunks in final check (#52)
-
-### Removed
 
 ## [6.0.0]
 ### BREAKING

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@pointcloudtechnology/resumablejs",
-  "version": "6.0.0",
+  "version": "7.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@pointcloudtechnology/resumablejs",
-      "version": "6.0.0",
+      "version": "7.0.0",
       "license": "MIT",
       "devDependencies": {
         "copy-webpack-plugin": "^11.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pointcloudtechnology/resumablejs",
-  "version": "6.0.0",
+  "version": "7.0.0",
   "description": "A JavaScript library for providing multiple simultaneous, stable, fault-tolerant and resumable/restartable uploads via the HTML5 File API.",
   "main": "dist/main.js",
   "private": false,


### PR DESCRIPTION
## [7.0.0]
### BREAKING
* A file that encountered an error doesn't return `1` for its progress anymore. Instead it will return the progress at which it stopped uploading.
* If a chunk encountered an error in the upload, it is now automatically retried in the final check.
    * Instead of reacting to `chunkError` or `fileError` events to manually retry such chunks, you should wait for the `failed` event.
    * The `failed` event indicates that Resumable couldn't upload some files, even in the final check. After that you might instruct the user to retry the upload or try to perform your own retries.

### Added
* Add debug request parameters (#51)
* A `failed` event is now fired when Resumable is finished but some files couldn't be uploaded (#52)
* Add `chunkStuckTimeout` option (#53)

### Changed
* Retry errored chunks in final check (#52)